### PR TITLE
Modify Module Manager

### DIFF
--- a/src/protocol/interfaces/IModuleManager.sol
+++ b/src/protocol/interfaces/IModuleManager.sol
@@ -17,11 +17,11 @@ interface IModuleManager {
     /// events
 
     event ModuleAdded(address indexed module);
-    event ModuleRemoved(address indexed module);
+    event ModuleDeprecated(address indexed module);
     event PHOCeilingUpdated(address indexed module, uint256 newPHOCeiling);
     event UpdatedModuleDelay(uint256 newDelay);
-    event ModuleMint(address indexed module, uint256 amount);
-    event ModuleBurn(address indexed module, uint256 amount);
+    event ModuleMint(address indexed module, address indexed to, uint256 amount);
+    event ModuleBurn(address indexed module, address indexed from, uint256 amount);
 
     enum Status {
         Unregistered,
@@ -36,10 +36,10 @@ interface IModuleManager {
         Status status;
     }
 
-    function mintPHO(uint256 _amount) external; // onlyModule
-    function burnPHO(uint256 _amount) external; // onlyModule
+    function mintPHO(address to, uint256 _amount) external; // onlyModule
+    function burnPHO(address from, uint256 _amount) external; // onlyModule
     function addModule(address _newModule) external; // onlyPHOGovernance
-    function removeModule(address _existingModule) external; // onlyPHOGovernance
+    function deprecateModule(address _existingModule) external; // onlyPHOGovernance
     function setPHOCeilingForModule(address _module, uint256 _newPHOCeiling) external; // onlyTONGovernance
     function setModuleDelay(uint256 _newDelay) external; // onlyPHOGovernance
 }

--- a/test/protocol/ModuleManager.t.sol
+++ b/test/protocol/ModuleManager.t.sol
@@ -25,11 +25,11 @@ contract ModuleManagerTest is BaseSetup {
 
     event Transfer(address indexed from, address indexed to, uint256 value);
     event ModuleAdded(address indexed module);
-    event ModuleRemoved(address indexed module);
+    event ModuleDeprecated(address indexed module);
     event PHOCeilingUpdated(address indexed module, uint256 newPHOCeiling);
     event UpdatedModuleDelay(uint256 newDelay);
-    event ModuleMint(address module, uint256 amount);
-    event ModuleBurn(address module, uint256 amount);
+    event ModuleMint(address indexed module, address indexed to, uint256 amount);
+    event ModuleBurn(address indexed module, address indexed from, uint256 amount);
 
     struct Module {
         uint256 phoCeiling;
@@ -45,16 +45,16 @@ contract ModuleManagerTest is BaseSetup {
     }
 
     function setUp() public {
-        // vm.prank(owner);
-
         vm.prank(PHOGovernance);
         moduleManager.addModule(module1);
 
         (,, uint256 startTime, ModuleManager.Status status) = moduleManager.modules(module1);
         assertEq(uint8(status), uint8(Status.Registered));
         assertEq(startTime, block.timestamp + moduleManager.moduleDelay());
+
         vm.prank(TONGovernance);
         moduleManager.setPHOCeilingForModule(module1, ONE_MILLION_D18);
+
         (uint256 newPhoCeiling,,,) = moduleManager.modules(module1);
         assertEq(newPhoCeiling, ONE_MILLION_D18);
     }
@@ -71,280 +71,238 @@ contract ModuleManagerTest is BaseSetup {
     function testCannotMintPHOUnregistered() public {
         vm.startPrank(dummyAddress);
         vm.expectRevert(abi.encodeWithSelector(UnregisteredModule.selector, dummyAddress));
-        moduleManager.mintPHO(ONE_MILLION_D18);
+        moduleManager.mintPHO(user1, ONE_MILLION_D18);
         vm.stopPrank();
     }
 
     function testCannotMintPHOCeilingMax() public {
         vm.startPrank(module1);
         vm.expectRevert(abi.encodeWithSelector(ModuleCeilingExceeded.selector));
-        moduleManager.mintPHO(ONE_MILLION_D18 * 2);
+        moduleManager.mintPHO(user1, ONE_MILLION_D18 * 2);
         vm.stopPrank();
     }
 
     function testMintPHO() public {
-        vm.startPrank(module1);
-        assertEq(pho.balanceOf(module1), 0);
-        (, uint256 phoMinted,,) = moduleManager.modules(module1);
-        assertEq(phoMinted, 0);
-        vm.expectEmit(true, false, false, true);
-        emit Transfer(address(0), module1, ONE_HUNDRED_THOUSAND_D18);
-        emit ModuleMint(module1, ONE_HUNDRED_THOUSAND_D18);
-        moduleManager.mintPHO(ONE_HUNDRED_THOUSAND_D18);
-        (, uint256 newPhoMinted,,) = moduleManager.modules(module1);
-        assertEq(pho.balanceOf(module1), ONE_HUNDRED_THOUSAND_D18);
-        assertEq(newPhoMinted, ONE_HUNDRED_THOUSAND_D18);
-        vm.stopPrank();
+        uint256 user1BalanceBefore = pho.balanceOf(user1);
+        (, uint256 phoMintedBefore,,) = moduleManager.modules(module1);
+
+        vm.expectEmit(true, true, false, true);
+        emit ModuleMint(module1, user1, ONE_HUNDRED_THOUSAND_D18);
+        vm.prank(module1);
+        moduleManager.mintPHO(user1, ONE_HUNDRED_THOUSAND_D18);
+
+        uint256 user1BalanceAfter = pho.balanceOf(user1);
+        (, uint256 phoMintedAfter,,) = moduleManager.modules(module1);
+
+        assertEq(user1BalanceAfter, user1BalanceBefore + ONE_HUNDRED_THOUSAND_D18);
+        assertEq(phoMintedAfter, phoMintedBefore + ONE_HUNDRED_THOUSAND_D18);
     }
 
     /// burnPHO() tests
 
     function testBurnDeprecatedModule() public {
-        _moduleMintPHO();
+        vm.prank(module1);
+        moduleManager.mintPHO(user1, ONE_HUNDRED_THOUSAND_D18);
+
         vm.prank(PHOGovernance);
-        moduleManager.removeModule(module1);
-        uint256 expectedModulePHO = pho.balanceOf(module1) - TEN_THOUSAND_D18 * 5;
+        moduleManager.deprecateModule(module1);
+
         uint256 burnAmount = TEN_THOUSAND_D18 * 5;
-        vm.startPrank(module1);
+        uint256 user1BalanceBefore = pho.balanceOf(user1);
+        (, uint256 module1PhoBalanceBefore,,) = moduleManager.modules(module1);
 
-        pho.approve(address(kernel), pho.balanceOf(module1));
-        vm.expectEmit(true, false, false, true);
-        emit Transfer(module1, address(0), burnAmount);
-        emit ModuleBurn(module1, burnAmount);
-        moduleManager.burnPHO(burnAmount);
-        assertEq(pho.balanceOf(module1), expectedModulePHO);
+        vm.prank(user1);
+        pho.approve(address(kernel), burnAmount);
 
-        (, uint256 newPhoMinted,,) = moduleManager.modules(module1);
+        vm.expectEmit(true, true, false, true);
+        emit ModuleBurn(module1, user1, burnAmount);
+        vm.prank(module1);
+        moduleManager.burnPHO(user1, burnAmount);
 
-        assertEq(newPhoMinted, expectedModulePHO);
-        vm.stopPrank();
+        uint256 user1BalanceAfter = pho.balanceOf(user1);
+        (, uint256 module1PhoBalanceAfter,,) = moduleManager.modules(module1);
+
+        assertEq(user1BalanceBefore, user1BalanceAfter + burnAmount);
+        assertEq(module1PhoBalanceBefore, module1PhoBalanceAfter + burnAmount);
     }
 
     function testCannotBurnUnregistered() public {
         vm.startPrank(dummyAddress);
         vm.expectRevert(abi.encodeWithSelector(UnregisteredModule.selector, dummyAddress));
-        moduleManager.burnPHO(ONE_HUNDRED_D18);
+        moduleManager.burnPHO(user1, ONE_HUNDRED_D18);
         vm.stopPrank();
     }
 
     function testCannotBurnZeroPHO() public {
         vm.startPrank(module1);
         vm.expectRevert(abi.encodeWithSelector(ZeroValue.selector));
-        moduleManager.burnPHO(0);
+        moduleManager.burnPHO(user1, 0);
         vm.stopPrank();
     }
 
     function testCannotBurnPastZero() public {
         vm.startPrank(module1);
         vm.expectRevert(abi.encodeWithSelector(ModuleBurnExceeded.selector));
-        moduleManager.burnPHO(ONE_MILLION_D18 * 2);
+        moduleManager.burnPHO(user1, ONE_MILLION_D18 * 2);
         vm.stopPrank();
     }
 
     function testBurnPHO() public {
-        _moduleMintPHO();
-        uint256 expectedModulePHO = pho.balanceOf(module1) - TEN_THOUSAND_D18 * 5;
+        vm.prank(module1);
+        moduleManager.mintPHO(user1, ONE_HUNDRED_THOUSAND_D18);
+
         uint256 burnAmount = TEN_THOUSAND_D18 * 5;
-        vm.startPrank(module1);
+        (, uint256 module1phoMintedBefore,,) = moduleManager.modules(module1);
+        uint256 user1BalanceBefore = pho.balanceOf(user1);
 
-        pho.approve(address(kernel), pho.balanceOf(module1));
-        vm.expectEmit(true, false, false, true);
-        emit Transfer(module1, address(0), burnAmount);
-        emit ModuleBurn(module1, burnAmount);
-        moduleManager.burnPHO(burnAmount);
-        assertEq(pho.balanceOf(module1), expectedModulePHO);
+        vm.prank(user1);
+        pho.approve(address(kernel), burnAmount);
 
-        (, uint256 newPhoMinted,,) = moduleManager.modules(module1);
+        vm.expectEmit(true, true, false, true);
+        emit ModuleBurn(module1, user1, burnAmount);
+        vm.prank(module1);
+        moduleManager.burnPHO(user1, burnAmount);
 
-        assertEq(newPhoMinted, expectedModulePHO);
-        vm.stopPrank();
+        (, uint256 module1phoMintedAfter,,) = moduleManager.modules(module1);
+        uint256 user1BalanceAfter = pho.balanceOf(user1);
+
+        assertEq(module1phoMintedBefore, module1phoMintedAfter + burnAmount);
+        assertEq(user1BalanceBefore, user1BalanceAfter + burnAmount);
     }
 
     /// addModule() tests
 
-    function testCannotAddRegisteredModule() public {
-        vm.startPrank(PHOGovernance);
-        (,,, ModuleManager.Status status) = moduleManager.modules(module1);
-        assertEq(uint8(status), uint8(Status.Registered));
-
+    function testCannotAddModuleAlreadyRegistered() public {
         vm.expectRevert(abi.encodeWithSelector(ModuleRegistered.selector));
+        vm.prank(PHOGovernance);
         moduleManager.addModule(module1);
-        (,,, ModuleManager.Status newStatus) = moduleManager.modules(module1);
-        assertEq(uint8(newStatus), uint8(Status.Registered)); // check that status hasn't changed
-        vm.stopPrank();
     }
 
     function testCannotAddZeroAddress() public {
-        vm.startPrank(PHOGovernance);
         vm.expectRevert(abi.encodeWithSelector(ZeroAddress.selector));
+        vm.prank(PHOGovernance);
         moduleManager.addModule(address(0));
-        vm.stopPrank();
     }
 
     function testCannotAddDeprecatedModule() public {
         vm.startPrank(PHOGovernance);
-        moduleManager.removeModule(module1);
-        (,,, ModuleManager.Status status) = moduleManager.modules(module1);
-        assertEq(uint8(status), uint8(Status.Deprecated));
+        moduleManager.deprecateModule(module1);
+
         vm.expectRevert(abi.encodeWithSelector(ModuleRegistered.selector));
         moduleManager.addModule(module1);
         vm.stopPrank();
     }
 
     function testCannotAddModuleNonPHOGovernance() public {
-        vm.startPrank(user1);
         vm.expectRevert(abi.encodeWithSelector(NotPHOGovernance.selector, user1));
+        vm.prank(user1);
         moduleManager.addModule(dummyAddress);
-        vm.stopPrank();
     }
 
     function testAddModule() public {
-        vm.startPrank(PHOGovernance);
-
-        (,,, ModuleManager.Status status) = moduleManager.modules(user1);
-        assertEq(uint8(status), uint8(Status.Unregistered));
+        address module2 = address(8);
 
         vm.expectEmit(true, false, false, true);
-        emit ModuleAdded(user1);
-        moduleManager.addModule(user1);
+        emit ModuleAdded(module2);
+        vm.prank(PHOGovernance);
+        moduleManager.addModule(module2);
 
-        (,, uint256 newStartTime, ModuleManager.Status newStatus) = moduleManager.modules(user1);
+        (,, uint256 newStartTime, ModuleManager.Status newStatus) = moduleManager.modules(module2);
         assertEq(uint8(newStatus), uint8(Status.Registered));
         assertEq(newStartTime, block.timestamp + moduleManager.moduleDelay());
-        vm.stopPrank();
     }
 
-    /// removeModule() tests
+    /// deprecateModule() tests
 
-    function testCannotRemoveUnRegisteredModule() public {
-        vm.startPrank(PHOGovernance);
+    function testCannotDeprecateUnRegisteredModule() public {
+        address unregisteredModule = address(10);
 
-        (,,, ModuleManager.Status status) = moduleManager.modules(user1);
-        assertEq(uint8(status), uint8(Status.Unregistered));
-
-        vm.expectRevert(abi.encodeWithSelector(UnregisteredModule.selector, user1));
-        moduleManager.removeModule(user1);
-        (,,, ModuleManager.Status newStatus) = moduleManager.modules(user1);
-        assertEq(uint8(newStatus), uint8(Status.Unregistered)); // check that status hasn't changed
-        vm.stopPrank();
+        vm.expectRevert(abi.encodeWithSelector(UnregisteredModule.selector, unregisteredModule));
+        vm.prank(PHOGovernance);
+        moduleManager.deprecateModule(unregisteredModule);
     }
 
     function testCannotRemoveZeroAddress() public {
-        vm.startPrank(PHOGovernance);
         vm.expectRevert(abi.encodeWithSelector(ZeroAddress.selector));
-        moduleManager.removeModule(address(0));
-        vm.stopPrank();
+        vm.prank(PHOGovernance);
+        moduleManager.deprecateModule(address(0));
     }
 
     function testCannotRemoveModuleNonPHOGovernance() public {
-        vm.startPrank(dummyAddress);
         vm.expectRevert(abi.encodeWithSelector(NotPHOGovernance.selector, dummyAddress));
-        moduleManager.removeModule(module1);
-        vm.stopPrank();
+        vm.prank(dummyAddress);
+        moduleManager.deprecateModule(module1);
     }
 
     function testRemoveModule() public {
-        vm.startPrank(PHOGovernance);
-
-        (,,, ModuleManager.Status status) = moduleManager.modules(module1);
-        assertEq(uint8(status), uint8(Status.Registered));
-
         vm.expectEmit(true, false, false, true);
-        emit ModuleRemoved(module1);
-        moduleManager.removeModule(module1);
+        emit ModuleDeprecated(module1);
+        vm.prank(PHOGovernance);
+        moduleManager.deprecateModule(module1);
 
         (uint256 newPhoCeiling,,, ModuleManager.Status newStatus) = moduleManager.modules(module1);
         assertEq(uint8(newStatus), uint8(Status.Deprecated));
-
         assertEq(newPhoCeiling, 0);
-        vm.stopPrank();
     }
 
     /// setPHOCeilingModule() tests
 
     function testCannotSetPHOCeilingZeroAddress() public {
-        vm.startPrank(TONGovernance);
         vm.expectRevert(abi.encodeWithSelector(ZeroAddress.selector));
+        vm.prank(TONGovernance);
         moduleManager.setPHOCeilingForModule(address(0), 0);
-        vm.stopPrank();
     }
 
     function testCannotSetPHOCeilingUnregistered() public {
-        vm.startPrank(TONGovernance);
         vm.expectRevert(abi.encodeWithSelector(UnregisteredModule.selector, dummyAddress));
+        vm.prank(TONGovernance);
         moduleManager.setPHOCeilingForModule(dummyAddress, ONE_MILLION_D18);
-        vm.stopPrank();
     }
 
     function testCannotSetPHOCeilingDeprecated() public {
         vm.prank(PHOGovernance);
-        moduleManager.removeModule(module1);
-        vm.startPrank(TONGovernance);
+        moduleManager.deprecateModule(module1);
+
         vm.expectRevert(abi.encodeWithSelector(DeprecatedModule.selector, module1));
+        vm.prank(TONGovernance);
         moduleManager.setPHOCeilingForModule(module1, ONE_MILLION_D18);
-        vm.stopPrank();
     }
 
-    // /// TODO - this test requires kernel.PHOCeiling() to be set
-    // function testCannotSetPHOCeilingMaxExceeded() public {
-    //     vm.startPrank(TONGovernance);
-    //     vm.expectRevert(abi.encodeWithSelector(MaxKernelPHOCeilingExceeded.selector);
-    //     moduleManager.setPHOCeilingForModule(module1, kernel.PHOCeiling() + 1);
-    //     vm.stopPrank();
-    // }
-
     function testCannotSetPHOCeilingNonTONGovernance() public {
-        vm.startPrank(dummyAddress);
         vm.expectRevert(abi.encodeWithSelector(NotTONGovernance.selector, dummyAddress));
+        vm.prank(dummyAddress);
         moduleManager.setPHOCeilingForModule(module1, ONE_MILLION_D18 * 10);
-        vm.stopPrank();
     }
 
     function testSetPHOCeilingModule() public {
-        uint256 expectedPHOCeiling = ONE_MILLION_D18 * 10;
-        vm.startPrank(TONGovernance);
+        uint256 newPhoCeiling = ONE_MILLION_D18 * 10;
+
         vm.expectEmit(true, false, false, true);
-        emit PHOCeilingUpdated(module1, expectedPHOCeiling);
-        moduleManager.setPHOCeilingForModule(module1, ONE_MILLION_D18 * 10);
+        emit PHOCeilingUpdated(module1, newPhoCeiling);
+        vm.prank(TONGovernance);
+        moduleManager.setPHOCeilingForModule(module1, newPhoCeiling);
 
         (uint256 phoCeiling,,,) = moduleManager.modules(module1);
-
-        assertEq(phoCeiling, expectedPHOCeiling);
-        vm.stopPrank();
+        assertEq(phoCeiling, newPhoCeiling);
     }
 
     function testCannotSetModuleDelayToZero() public {
-        vm.startPrank(PHOGovernance);
         vm.expectRevert(abi.encodeWithSelector(ZeroValue.selector));
+        vm.prank(PHOGovernance);
         moduleManager.setModuleDelay(0);
-        vm.stopPrank();
     }
 
     function testCannotSetModuleDelayOnlyPHOGovernance() public {
-        vm.startPrank(dummyAddress);
         vm.expectRevert(abi.encodeWithSelector(NotPHOGovernance.selector, dummyAddress));
-
+        vm.prank(dummyAddress);
         moduleManager.setModuleDelay(0);
-        vm.stopPrank();
     }
 
     function testSetModuleDelay() public {
-        vm.startPrank(PHOGovernance);
         vm.expectEmit(false, false, false, true);
         emit UpdatedModuleDelay(3 weeks);
+        vm.prank(PHOGovernance);
         moduleManager.setModuleDelay(3 weeks);
         assertEq(moduleManager.moduleDelay(), 3 weeks);
-        vm.stopPrank();
-    }
-
-    /// helpers
-
-    /// @notice helper function to mint 100k PHO to module1
-    function _moduleMintPHO() internal {
-        vm.startPrank(module1);
-        assertEq(pho.balanceOf(module1), 0);
-        moduleManager.mintPHO(ONE_HUNDRED_THOUSAND_D18);
-        assertEq(pho.balanceOf(module1), ONE_HUNDRED_THOUSAND_D18);
-        vm.stopPrank();
     }
 }


### PR DESCRIPTION
Modify `ModuleManager`.

Main changes:
1. `ModuleManager.sol` - added to param to mint and from param to burn. Also renamed removeModule to deprecateModule.
2. `ModuleManager.t.sol` - overall tests changes to accommodate new parameters and reorganize tests.