### PR TITLE
fix(npm): ensure foundry exists for npm prepublish build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
- Fix bug as seen in this workflow failure https://github.com/ekonomia-tech/protocol-alpha/actions/runs/3595898137